### PR TITLE
Install krb5-devel, not krb5-mini-devel

### DIFF
--- a/recipe/php_meal.rb
+++ b/recipe/php_meal.rb
@@ -168,7 +168,7 @@ class PhpMeal
       ImageMagick-devel
       cyrus-sasl-devel
       imap-devel
-      krb5-mini-devel
+      krb5-devel
       net-snmp-devel)
   end
 


### PR DESCRIPTION
The docker container now uses krb5, not krb5-mini, and the devel package
needs to match.