### PR TITLE
Disable ruby versioning during gem install

### DIFF
--- a/recipe/bundler.rb
+++ b/recipe/bundler.rb
@@ -21,7 +21,7 @@ class BundlerRecipe < BaseRecipe
         FileUtils.rm_rf("#{tmpdir}/*")
 
         in_gem_env(tmpdir) do
-          system("unset RUBYOPT; gem install bundler --version #{version} --no-ri --no-rdoc --env-shebang")
+          system("unset RUBYOPT; gem install bundler --version #{version} --no-ri --no-rdoc --env-shebang --no-format-executable")
           system("rm -f bundler-#{version}.gem")
           system("rm -rf cache/bundler-#{version}.gem")
           system("tar czvf #{current_dir}/#{archive_filename} .")


### PR DESCRIPTION
This fixes `bundle` being named `bundle.ruby2.3` which broke the `binary-builder` pipeline.

Signed-off-by: André Duffeck <aduffeck@suse.com>